### PR TITLE
ci: add Trivy and Semgrep security scans, pin package versions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,97 @@
+name: Semgrep SAST
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, Monday 06:00 UTC (mirrors the Trivy scan)
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned by digest (the container equivalent of an action SHA pin). # 1.166.0
+  SEMGREP_IMAGE: semgrep/semgrep@sha256:c180f0c93a17b420c0af5006214a29d3c747c5459c732b740191adf657dd0068
+  SEMGREP_CONFIG: "--config p/javascript --config p/typescript --config p/security-audit --config p/secrets"
+
+jobs:
+  semgrep:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # Full report, all severities. Never fails here (--metrics=off keeps code off Semgrep's cloud).
+      - name: Semgrep scan (report)
+        run: |
+          docker run --rm -v "$PWD":/src -w /src "$SEMGREP_IMAGE" \
+            semgrep scan $SEMGREP_CONFIG --metrics=off --text --output semgrep-report.txt || true
+
+      - name: Add report to job summary
+        if: always()
+        run: |
+          {
+            echo "## Semgrep SAST"
+            echo ""
+            echo '```'
+            if [ -s semgrep-report.txt ]; then
+              cat semgrep-report.txt
+            else
+              echo "No findings reported."
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: semgrep-report
+          path: semgrep-report.txt
+          retention-days: 30
+
+      # Sticky PR comment via gh CLI (no third-party action, free plan friendly).
+      - name: Post/update PR comment
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BODY_FILE="$(mktemp)"
+
+          {
+            echo "## 🔎 Semgrep SAST"
+            echo ""
+            echo "Rules: \`p/javascript p/typescript p/security-audit p/secrets\` — full report attached as the **semgrep-report** artifact."
+            echo ""
+            echo '```'
+          } > "$BODY_FILE"
+
+          # GitHub comment limit is ~65 KB; keep well under it and point to the artifact if truncated.
+          MAX_BYTES=50000
+          if [ ! -s semgrep-report.txt ]; then
+            echo "No findings reported." >> "$BODY_FILE"
+          elif [ "$(wc -c < semgrep-report.txt)" -gt "$MAX_BYTES" ]; then
+            head -c "$MAX_BYTES" semgrep-report.txt >> "$BODY_FILE"
+            printf '\n... report truncated — see the full semgrep-report artifact for this run.\n' >> "$BODY_FILE"
+          else
+            cat semgrep-report.txt >> "$BODY_FILE"
+          fi
+          echo '```' >> "$BODY_FILE"
+
+          # Sticky comment: edit the bot's previous comment, or create one on first run.
+          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body-file "$BODY_FILE"
+
+      # Gate: fail the build on ERROR-severity findings. Must be the last step.
+      - name: Semgrep scan (gate)
+        run: |
+          docker run --rm -v "$PWD":/src -w /src "$SEMGREP_IMAGE" \
+            semgrep scan $SEMGREP_CONFIG --metrics=off --severity ERROR --error

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,122 @@
+name: Trivy Full Scan
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, Monday 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: trivy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Filesystem scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # Vuln/secret/misconfig: all severities, never fails here.
+      - name: Trivy scan (report)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig
+          format: table
+          output: trivy-report.txt
+          exit-code: "0"
+
+      # Licenses: only restricted (HIGH) / forbidden (CRITICAL); skip notice/permissive (LOW).
+      - name: Trivy scan (licenses)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: license
+          severity: HIGH,CRITICAL
+          format: table
+          output: trivy-license.txt
+          exit-code: "0"
+
+      - name: Combine reports
+        if: always()
+        run: |
+          if [ -s trivy-license.txt ]; then
+            printf '\n===== Restricted / forbidden licenses =====\n' >> trivy-report.txt
+            cat trivy-license.txt >> trivy-report.txt
+          fi
+
+      - name: Add report to job summary
+        if: always()
+        run: |
+          {
+            echo "## Trivy Full Scan"
+            echo ""
+            echo '```'
+            if [ -s trivy-report.txt ]; then
+              cat trivy-report.txt
+            else
+              echo "No findings reported."
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-report
+          path: trivy-report.txt
+          retention-days: 30
+
+      # Sticky PR comment via gh CLI (no third-party action, free plan friendly).
+      - name: Post/update PR comment
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BODY_FILE="$(mktemp)"
+
+          {
+            echo "## 🛡️ Trivy Full Scan"
+            echo ""
+            echo "Scanners: \`vuln,secret,misconfig,license\` — full report attached as the **trivy-report** artifact."
+            echo ""
+            echo '```'
+          } > "$BODY_FILE"
+
+          # GitHub comment limit is ~65 KB; keep well under it and point to the artifact if truncated.
+          MAX_BYTES=50000
+          if [ ! -s trivy-report.txt ]; then
+            echo "No findings reported." >> "$BODY_FILE"
+          elif [ "$(wc -c < trivy-report.txt)" -gt "$MAX_BYTES" ]; then
+            head -c "$MAX_BYTES" trivy-report.txt >> "$BODY_FILE"
+            printf '\n... report truncated — see the full trivy-report artifact for this run.\n' >> "$BODY_FILE"
+          else
+            cat trivy-report.txt >> "$BODY_FILE"
+          fi
+          echo '```' >> "$BODY_FILE"
+
+          # Sticky comment: edit the bot's previous comment, or create one on first run.
+          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body-file "$BODY_FILE"
+
+      # Gate: fail the build on HIGH/CRITICAL findings. Must be the last step.
+      - name: Trivy scan (gate)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig,license
+          severity: HIGH,CRITICAL
+          format: table
+          exit-code: "1"

--- a/package.json
+++ b/package.json
@@ -15,24 +15,24 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@fontsource/inter": "^5.0.0",
-    "@fontsource/kanit": "^5.0.0",
-    "@fontsource/rubik": "^5.0.0",
-    "@fontsource/space-grotesk": "^5.0.0",
-    "@fontsource/work-sans": "^5.0.0",
-    "@solidjs/router": "^0.15.0",
-    "solid-js": "^1.9.0"
+    "@fontsource/inter": "5.2.8",
+    "@fontsource/kanit": "5.2.8",
+    "@fontsource/rubik": "5.2.8",
+    "@fontsource/space-grotesk": "5.2.10",
+    "@fontsource/work-sans": "5.2.8",
+    "@solidjs/router": "0.15.4",
+    "solid-js": "1.9.13"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.3.1",
-    "@types/node": "latest",
-    "autoprefixer": "latest",
-    "eslint": "latest",
-    "postcss": "latest",
-    "tailwindcss": "latest",
-    "typescript": "latest",
-    "vite": "^8.0.16",
-    "vite-plugin-solid": "^2.10.0",
-    "wrangler": "^4.103.0"
+    "@tailwindcss/postcss": "4.3.1",
+    "@types/node": "26.0.0",
+    "autoprefixer": "10.5.0",
+    "eslint": "10.5.0",
+    "postcss": "8.5.15",
+    "tailwindcss": "4.3.1",
+    "typescript": "6.0.3",
+    "vite": "8.0.16",
+    "vite-plugin-solid": "2.11.12",
+    "wrangler": "4.103.0"
   }
 }


### PR DESCRIPTION
## Summary

- Add Trivy filesystem scan workflow (vuln, secret, misconfig, license) with PR comment reporting and HIGH/CRITICAL gate
- Add Semgrep SAST workflow (javascript, typescript, security-audit, secrets rulesets) with PR comment reporting and ERROR-severity gate
- Pin all `package.json` dependency versions to exact installed versions (remove `^` ranges and `latest` tags)

## Test plan

- [ ] Verify Trivy workflow triggers on this PR and posts a comment
- [ ] Verify Semgrep workflow triggers on this PR and posts a comment
- [ ] Confirm both gates pass (no HIGH/CRITICAL vulns or ERROR-severity SAST findings)
- [ ] Confirm `npm install` still resolves correctly with pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)